### PR TITLE
Added support for ISO 8601 dates

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ exports.dateFormat = function(str) {
     , defaults = [null, ' 00:00', ':00', ' +0000']
     , match = str.match(rx)
     
-  if (!match) {
+  if (!match || str === (new Date(str)).toISOString()) {
     return false
   }
   for (var i = 1; i < 4; i++) {

--- a/test.js
+++ b/test.js
@@ -1702,6 +1702,7 @@ describe('Respectify Unit Tests', function() {
         , '02-05-2015 00:00'
         , '02-05-2015 00:00:00'
         , '02-05-2015 00:00:00 -0800'
+        , '2015-02-05T00:00:00.000Z'
         ].forEach(function(x) {
           var obj = { time: x }
           assert.ifError(inv(obj, 'time', paramSpec))


### PR DESCRIPTION
the dateFormat function mangles ISO 8601 dates, checking to see if the date is already ISO 8601 prevents this.